### PR TITLE
prevent showing tutorials twice

### DIFF
--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/DifferentiableSwiftExamples.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/DifferentiableSwiftExamples.md
@@ -23,7 +23,3 @@ TODO: A good introduction story here soon.
 
 ### Tutorials
 - <doc:/tutorials/DifferentiableSwiftExamples>
-- <doc:/tutorials/MachineSetup>
-- <doc:/tutorials/DifferentiableFunctions>
-- <doc:/tutorials/DifferentiableObjects>
-- <doc:/tutorials/GradientDescent>


### PR DESCRIPTION
Now only shows the top level tutorial name where sections can by found by collapsing the currently single present tutorial. 
Previously it would also show the tutorial's content at this level of navigation thus presenting double references