### PR TITLE
Add introductory documentation on usage of differentiable Swift

### DIFF
--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/BasicDifferentiation.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/BasicDifferentiation.md
@@ -1,4 +1,0 @@
-# Basic Differentiation
-Basic Differentiation
-
-## Coming Soon

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/BasicGradientDescent.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/BasicGradientDescent.md
@@ -1,4 +1,0 @@
-# Basic Gradient Descent
-A simple example of how to gradient descent using Swift's automatic differentiation language feature. 
-
-## Coming Soon

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/CustomDerivatives.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/CustomDerivatives.md
@@ -1,4 +1,0 @@
-# Custom Derivatives
-How to write custom derivatives for functions or for 3rd party code.
-
-## Coming Soon

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/DifferentiableSwiftExamples.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/DifferentiableSwiftExamples.md
@@ -8,7 +8,15 @@ Articles and tutorials on the experimental language feature of differentiable Sw
 
 ## Overview
 
-TODO: A good introduction story here soon.
+Differentiable Swift is an experimental language feature for the [Swift language](https://www.swift.org) that is currently
+in the [pitch phase](https://forums.swift.org/t/differentiable-programming-for-gradient-based-machine-learning/42147) of
+the Swift Evolution process. The goal of this feature is to provide first-class, language-integrated support for
+differentiable programming, making Swift the first general-purpose, statically typed programming language to have automatic
+differentiation built in.
+
+Differentiable Swift is purely a language feature and isn't tied to any specific machine learning framework or platform.
+It provides a means of building such frameworks in Swift, and works wherever Swift does: from Linux to macOS to
+ [WebAssembly](https://swiftwasm.org).
 
 <!-- This section defines our navigation bar on the left as well -->
 ## Topics
@@ -16,10 +24,7 @@ TODO: A good introduction story here soon.
 ### Articles
 
 - <doc:Setup>
-- <doc:BasicDifferentiation>
-- <doc:CustomDerivatives>
-- <doc:ManuallyDefinedTangentVectors>
-- <doc:BasicGradientDescent>
+- <doc:UsingDifferentiableSwift>
 - <doc:SharpEdgesInDifferentiableSwift>
 
 ### Tutorials

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/ManuallyDefinedTangentVectors.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/ManuallyDefinedTangentVectors.md
@@ -1,4 +1,0 @@
-# Manually Defined Tangent Vectors
-How to manually define tangent vectors for types conforming to the `Differentiable` protocol.
-
-## Coming Soon

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-01-04.swift
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-01-04.swift
@@ -5,4 +5,4 @@ func squared(_ input: Double) -> Double {
     input * input
 }
 
-let (value, gradient) = valueWithGradient(at: 3.0, of: square)
+let (value, gradient) = valueWithGradient(at: 3.0, of: squared)

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-01-05.swift
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-01-05.swift
@@ -5,7 +5,7 @@ func squared(_ input: Double) -> Double {
     input * input
 }
 
-let (value, gradient) = valueWithGradient(at: 3.0, of: square)
+let (value, gradient) = valueWithGradient(at: 3.0, of: squared)
 print("The value is \(value), and the gradient is \(gradient).")
 
 // The value is 9.0, and the gradient is 6.0.

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/SharpEdgesInDifferentiableSwift.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/SharpEdgesInDifferentiableSwift.md
@@ -1,6 +1,6 @@
 # Sharp edges in differentiable Swift
 
-This is an overview of some of the currently missing capabilities in differentiable Swift.
+An overview of some of the currently missing capabilities in differentiable Swift.
 
 ## Overview
 

--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/UsingDifferentiableSwift.md
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/UsingDifferentiableSwift.md
@@ -1,0 +1,83 @@
+# Using differentiable Swift
+Introduces differentiable Swift and how to use it to define differentiable functions and types.
+
+## Overview
+
+Differentiable Swift integrates first-class support for automatic differentiation right into the Swift language.
+This means that the compiler can generate derivatives of arbitrary Swift code, and the type system can identify and provide clear messages for many common programming errors around differentiability.
+
+Differentiable functions are a key enabler of the extremely powerful technique of gradient descent optimization, which powers much of deep learning, and are useful in many other applications.
+
+As an experimental feature, activation of differentiable Swift is gated behind the following import statement:
+
+```swift
+import _Differentiation
+```
+
+which must be present in any Swift file taking advantage of differentiation.
+
+
+### Differentiable functions
+
+You can mark a function as being differentiable if it has at least one differentiable parameter and
+differentiable result. The `@differentiable` annotation is used to mark the function, and the
+`reverse` specifier further clarifies that we want to use reverse-mode differentiation.
+
+```swift
+@differentiable(reverse)
+func squared(_ x: Float) -> Float {
+    return x * x
+}
+```
+
+In addition to letting the compiler define derivatives for Swift functions, you can register custom
+derivatives for any differentiable function. This is necessary for non-Swift functions or ones that
+reside in external modules you don't control, if you want these functions to be differentiable. For
+example, registering a derivative for the above `squared()` function might look like the following:
+
+```swift
+@derivative(of: squared)
+func vjpSquared(_ input: Double) -> (
+    value: Double,
+    pullback: (Double) -> Double
+) {
+    let output = squared(value)
+    func pullback(_ tangentVector: Double) -> Double {
+        return tangentVector * 2 * value
+    }
+    return (value: output, pullback: pullback)
+}
+```
+
+### Differentiable types
+
+To declare a type as being differentiable, it needs to conform to the `Differentiable` protocol.
+Generally, types are differentiable if they are continuous or if all of their properties are
+continuous and `Differentiable`. Differentiable types can have non-Differentiable properties, if
+those properties are annotated with `@noDerivative`. For example, the following is a custom struct
+that is `Differentiable`:
+
+``` swift
+struct MyValue: Differentiable {
+    var x: Float
+    var y: Double
+    @noDerivative
+    let isTracked: Bool
+}
+```
+
+
+### Obtaining and working with gradients and pullbacks
+
+To activate the differentiation machinery, there are some special built-in functions in the
+Differentiation module within the Swift standard library that can give you the value from the
+forward pass through a differentiable function as well as the backward pass.
+
+For functions with scalar outputs, `valueWithGradient(at:of:)` will return both the value and the
+calculated gradient at a given input value:
+
+```swift
+let (value, gradient) = valueWithGradient(at: 3.0, of: square)
+print("The value is \(value), and the gradient is \(gradient)")
+// Prints a value of 9.0 and a gradient of 6.0.
+```


### PR DESCRIPTION
This populates the documentation on using differentiable Swift with some basic introductory content and finishes the table of contents. We can expand upon this with subsequent API documentation and further description of differentiable Swift concepts.

This also corrects a couple of typos in the code tutorials.