### PR TITLE
switch usage of torch.autograd.functional.vjp to torch.autograd.grad …

### DIFF
--- a/Benchmarks/BuildingSimulation/PyTorch/PyTorchSimulator.py
+++ b/Benchmarks/BuildingSimulation/PyTorch/PyTorchSimulator.py
@@ -162,7 +162,7 @@ def measure(function, arguments):
     start = time.time()
     result = function(arguments)
     end = time.time()
-    return end - start
+    return (end - start, result)
 
 
 def fullPipe(simParams):
@@ -180,18 +180,19 @@ warmup = 3
 
 for i in range(trials):
     
-    forwardOnly = measure(fullPipe, SimParamsConstant)
+    inputs = SimParamsConstant
+    forwardOnlyTime, forwardOutput = measure(fullPipe, inputs)
     
     simParams = SimParamsConstant
     def getGradient(simParams):
-        endTemperature, gradient = torch.autograd.functional.vjp(simulate, SimParamsConstant)
+        gradient = torch.autograd.grad(forwardOutput, inputs)
         return gradient
 
 
-    gradientTime = measure(getGradient, simParams)
+    gradientTime, gradient = measure(getGradient, simParams)
     
     if i >= warmup:
-        totalForwardTime += forwardOnly
+        totalForwardTime += forwardOnlyTime
         totalGradientTime += gradientTime
 
 


### PR DESCRIPTION
…(30% faster)

They give the same numeric result, but torch.autograd.grad is a more standard usage, and performance is better for this use case. torch.autograd.functional.vjp is unnecessary because there's no custom input to the pullback, and it was implicitly calling the pullback with the normal unit vector, which is exactly what torch.autograd.grad does anyway