### PR TITLE
fix: TensorFlow memory and performance fixes

### DIFF
--- a/Benchmarks/BuildingSimulation/TensorFlow/TensorFlowSimulator.py
+++ b/Benchmarks/BuildingSimulation/TensorFlow/TensorFlowSimulator.py
@@ -227,6 +227,15 @@ def fullPipe(simParams):
     return loss
 
 
+@tf.function
+def getGradient(simParams):
+    with tf.GradientTape() as tape:
+        endTemperature = simulate(simParams)
+
+        gradient = tape.gradient(endTemperature, [simParams])
+    return gradient
+
+
 totalForwardTime = 0
 totalGradientTime = 0
 
@@ -235,13 +244,6 @@ for i in range(trials + warmup):
     forwardTime, forwardOutput = measure(fullPipe, SimParamsConstant)
 
     simParams = tf.Variable(SimParamsConstant)
-    def getGradient(simParams):
-        with tf.GradientTape() as tape:
-            endTemperature = simulate(simParams)
-
-            gradient = tape.gradient(endTemperature, [simParams])
-        return gradient
-
 
     gradientTime, gradient = measure(getGradient, simParams)
 

--- a/Benchmarks/BuildingSimulation/TensorFlow/TensorFlowSimulator.py
+++ b/Benchmarks/BuildingSimulation/TensorFlow/TensorFlowSimulator.py
@@ -193,7 +193,7 @@ def simulate(simParams):
     startingTemp = simParams[SimParamsIndices.istartingTemp][0]
     slab = slab * tf.constant([0.0, 1, 1, 1, 1]) + startingTemp * tf.constant([1.0, 0, 0, 0, 0])
 
-    for i in range(0, timesteps):
+    for i in tf.range(timesteps):
         tankAndQuanta = updateSourceTank(tank, quanta)
         tank = tankAndQuanta[0]
         quanta = tankAndQuanta[1]


### PR DESCRIPTION
When running BuildingSimulation benchmarks, I observed a very high amount of memory usage (MacBook Pro, M1 Max, 32GB RAM) during high-timestep simulations using TensorFlow. Some cases (100,000 timestep, single trial) failed to complete, with warnings thrown from TF about 'large unrolled loops'. [TF documentation suggested](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/autograph/g3doc/reference/common_errors.md#warning-large-unrolled-loop-detected) using TensorFlow's control flow:`tf.range`. To keep each trial isolated and independent, I'm keeping the trials' `range` usage as Python's.

The observed effect of these two changes is that overall memory usage is reduced, lowering RAM hardware requirements, and performance is increased by decorating the `getGradient` function with `@tf.function`. [This decoration is recommended](https://www.tensorflow.org/guide/function) to avoid eager execution, and is a basic and straightforward measure to increase performance.