### PR TITLE
Defining custom derivatives: Correct `value` variable to `input`

### DIFF
--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-02-05.swift
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-02-05.swift
@@ -9,9 +9,9 @@ func vjpSquared(_ input: Double) -> (
     value: Double,
     pullback: (Double) -> Double
 ) {
-    let output = squared(value)
+    let output = squared(input)
     func pullback(_ tangentVector: Double) -> Double {
-        return tangentVector * 2 * value
+        return tangentVector * 2 * input
     }
     return (value: output, pullback: pullback)
 }


### PR DESCRIPTION
The tutorial code for "Defining custom derivatives" uses `value` where it should use `input`. `value` isn't defined except as a tuple value name in the return type.

<img width="521" alt="Screenshot 2024-09-02 at 9 26 19 PM" src="https://github.com/user-attachments/assets/cf36bbd0-b8ef-4b00-82ea-7b1b06e4ed27">

In VS Code:

<img width="437" alt="Screenshot 2024-09-02 at 9 26 33 PM" src="https://github.com/user-attachments/assets/d3fcf020-3957-4ff8-b68d-d945c5f9ce3d">

Fixed:

<img width="441" alt="Screenshot 2024-09-02 at 9 26 45 PM" src="https://github.com/user-attachments/assets/e7b24b99-31f7-41eb-9765-53228b16add9">



