### PR TITLE
Making external functions differentiable: Correct variable names

### DIFF
--- a/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-03-03.swift
+++ b/Sources/DifferentiableSwiftExamplesDocumentation/DifferentiableSwiftExamples.docc/Resources/Code/DifferentiableFunctions/DifferentiableFunctions-03-03.swift
@@ -17,6 +17,6 @@ public func minVJP<T: Comparable & Differentiable>(
 }
 
 let (value, gradient) = valueWithGradient(at: 3.0, 4.0, of: min)
-print("The min() value is \(value2), and the gradient is \(gradient2).")
+print("The min() value is \(value), and the gradient is \(gradient).")
 
 // The min() value is 3.0, and the gradient is (1.0, 0.0).


### PR DESCRIPTION
Fix variable names: `value2` -> `value` and `gradient2` -> `gradient`.

VS Code:

<img width="898" alt="Screenshot 2024-09-02 at 9 46 23 PM" src="https://github.com/user-attachments/assets/912494c0-84e5-46c1-9165-2025a667789e">

After:

<img width="842" alt="Screenshot 2024-09-02 at 9 46 37 PM" src="https://github.com/user-attachments/assets/47706279-5e70-4c60-91dd-ec87fc171526">

